### PR TITLE
Fix Maven project setup for Eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,15 @@
 							<goal>testCompile</goal>
 						</goals>
 					</execution>
+
+					<!-- Make Scala source code visible to Maven.  This is required for
+                                             correct work of Eclipse/Scala integration. -->
+                                        <execution>
+                                        	<id>scala-add-source</id>
+                                        	<goals>
+                                        		<goal>add-source</goal>
+                                        	</goals>
+                                        </execution>
 				</executions>
 				<configuration>
 					<jvmArgs>


### PR DESCRIPTION
Scala IDE (package for Eclipse) doesn't show the Scala code when Maven project is imported into Eclipse.
To fix this, the `scala-maven-plugin` should have explicit execution with goal `add-source`.
